### PR TITLE
Enabling internal pull-up resistor

### DIFF
--- a/listen-for-shutdown.py
+++ b/listen-for-shutdown.py
@@ -6,7 +6,7 @@ import subprocess
 
 
 GPIO.setmode(GPIO.BCM)
-GPIO.setup(3, GPIO.IN)
+GPIO.setup(3, GPIO.IN, pull_up_down=GPIO.PUD_UP)
 GPIO.wait_for_edge(3, GPIO.FALLING)
 
 subprocess.call(['shutdown', '-h', 'now'], shell=False)


### PR DESCRIPTION
Without pull-up pin is floating and can cause random shutdowns.