### PR TITLE
Use gpiozero library instead of RPi.GPIO

### DIFF
--- a/listen-for-shutdown.py
+++ b/listen-for-shutdown.py
@@ -4,7 +4,7 @@
 from gpiozero import Button
 import subprocess
 
-button = Button(2)
+button = Button(3)
 
 button.wait_for_press()
 

--- a/listen-for-shutdown.py
+++ b/listen-for-shutdown.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python
 
 
-import RPi.GPIO as GPIO
+from gpiozero import Button
 import subprocess
 
+button = Button(2)
 
-GPIO.setmode(GPIO.BCM)
-GPIO.setup(3, GPIO.IN, pull_up_down=GPIO.PUD_UP)
-GPIO.wait_for_edge(3, GPIO.FALLING)
+button.wait_for_press()
 
 subprocess.call(['shutdown', '-h', 'now'], shell=False)


### PR DESCRIPTION
As gpiozero library is installed by default, the python code becomes simplier using it.