### PR TITLE
Added 3 seconds delay to shutdown button ( long press delay )

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # pi-power-button
 
-Scripts used in our official [Raspberry Pi power button guide](https://howchoo.com/g/mwnlytk3zmm/how-to-add-a-power-button-to-your-raspberry-pi).
+## Details
+
+This software allows to turn on and off your raspberry. For turning off the raspberry you will need to hold the button for 3seconds. This makes unintentional turn offs or static current not turn off the raspberry randomly.
 
 ## Installation
 
-1. [Connect to your Raspberry Pi via SSH](https://howchoo.com/g/mgi3mdnlnjq/how-to-log-in-to-a-raspberry-pi-via-ssh)
-1. Clone this repo: `git clone https://github.com/Howchoo/pi-power-button.git`
+1. Clone this repo: `git clone https://github.com/ImpressiveTaste/pi-power-button`
 1. Optional: Edit line 9/10 in listen-for-shutdown.py to your preferred pin (Please see "Is it possible to use another pin other than Pin 5 (GPIO 3/SCL)?" below!)
 1. Run the setup script: `./pi-power-button/script/install`
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# pi-power-button
+# pi-power-button - 3 seconds delay
 
 ## Details
 

--- a/listen-for-shutdown.py
+++ b/listen-for-shutdown.py
@@ -3,10 +3,21 @@
 
 import RPi.GPIO as GPIO
 import subprocess
-
+import time
 
 GPIO.setmode(GPIO.BCM)
 GPIO.setup(3, GPIO.IN, pull_up_down=GPIO.PUD_UP)
-GPIO.wait_for_edge(3, GPIO.FALLING)
+
+stay=1 #incidcates if shutdown hasbeen sent correctly
+
+while stay:
+	GPIO.wait_for_edge(3, GPIO.FALLING) #button is pressed
+	for i in range(30): #wait for a second
+		time.sleep(0.1)
+		if GPIO.input(3) == 1: #if button not pressed
+			stay=1
+			break
+		else:
+			stay=0
 
 subprocess.call(['shutdown', '-h', 'now'], shell=False)


### PR DESCRIPTION
The delay is useful to avoid the raspberry to turn of randomly due to static and also used to make the turn off process more reliable (bumping into the switch will not turn off the raspberry).

Only a long, 3 seconds press, will make the raspberry turn off safely.