### PR TITLE
Long press delay (parameterized)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Scripts used in our official [Raspberry Pi power button guide](https://howchoo.c
 ## Installation
 
 1. [Connect to your Raspberry Pi via SSH](https://howchoo.com/g/mgi3mdnlnjq/how-to-log-in-to-a-raspberry-pi-via-ssh)
-1. Clone this repo: `git clone https://github.com/Howchoo/pi-power-button.git`
+1. Clone this repo: `git clone https://github.com/N6RDV/pi-power-button.git`
 1. Optional: Edit line 9/10 in listen-for-shutdown.py to your preferred pin (Please see "Is it possible to use another pin other than Pin 5 (GPIO 3/SCL)?" below!)
 1. Run the setup script: `./pi-power-button/script/install`
 

--- a/listen-for-shutdown.py
+++ b/listen-for-shutdown.py
@@ -17,8 +17,7 @@ GPIO.setup(button_gpio, GPIO.IN, pull_up_down=GPIO.PUD_UP)
 GPIO.setup(relay_gpio, GPIO.OUT)
 
 def main():
-  relay_state=True
-  GPIO.output(relay_gpio, relay_state)
+  relay_state=GPIO.input(relay_gpio)
   while True:
     GPIO.wait_for_edge(button_gpio, GPIO.FALLING)
     counter = 0

--- a/listen-for-shutdown.py
+++ b/listen-for-shutdown.py
@@ -17,7 +17,7 @@ GPIO.setup(button_gpio, GPIO.IN, pull_up_down=GPIO.PUD_UP)
 GPIO.setup(relay_gpio, GPIO.OUT)
 
 def main():
-  relay_state=False
+  relay_state=True
   GPIO.output(relay_gpio, relay_state)
   while True:
     GPIO.wait_for_edge(button_gpio, GPIO.FALLING)

--- a/listen-for-shutdown.py
+++ b/listen-for-shutdown.py
@@ -9,8 +9,8 @@ from time import sleep
 button_gpio=3
 relay_gpio=4
 
-short_press=0.5
-long_press=10
+short_press=0.1
+long_press=5
 
 GPIO.setmode(GPIO.BCM)
 GPIO.setup(button_gpio, GPIO.IN, pull_up_down=GPIO.PUD_UP)
@@ -33,6 +33,7 @@ def main():
       relay_state = not relay_state
       print('Changing relay state to: ' + str(relay_state))
       GPIO.output(relay_gpio, relay_state)
+      time.sleep(0.5)
 
 if __name__ == '__main__':
   main()

--- a/listen-for-shutdown.py
+++ b/listen-for-shutdown.py
@@ -6,23 +6,33 @@ import subprocess
 import time
 from time import sleep
 
-gpio_pin=3
-long_press=0
+button_gpio=3
+relay_gpio=4
+
+short_press=0.5
+long_press=10
 
 GPIO.setmode(GPIO.BCM)
-GPIO.setup(gpio_pin, GPIO.IN, pull_up_down=GPIO.PUD_UP)
+GPIO.setup(button_gpio, GPIO.IN, pull_up_down=GPIO.PUD_UP)
+GPIO.setup(relay_gpio, GPIO.OUT)
 
 def main():
+  relay_state=False
+  GPIO.output(relay_gpio, relay_state)
   while True:
-    GPIO.wait_for_edge(gpio_pin, GPIO.FALLING)
+    GPIO.wait_for_edge(button_gpio, GPIO.FALLING)
     counter = 0
-    while GPIO.input(gpio_pin) == 0 and counter < long_press:
+    while GPIO.input(button_gpio) == 0 and counter < long_press:
       time.sleep(0.1)
-      counter += 1
+      counter = round(counter + 0.1, 1)
       print('Shutdown button is pressed ' + str(counter))
     if counter >= long_press:
       print('Shutting down')
       subprocess.call(['shutdown', '-h', 'now'], shell=False)
+    elif counter >= short_press:
+      relay_state = not relay_state
+      print('Changing relay state to: ' + str(relay_state))
+      GPIO.output(relay_gpio, relay_state)
 
 if __name__ == '__main__':
   main()

--- a/listen-for-shutdown.py
+++ b/listen-for-shutdown.py
@@ -6,7 +6,7 @@ import time
 from time import sleep
 
 gpio_pin=3
-long_press=30
+long_press=0
 
 GPIO.setmode(GPIO.BCM)
 GPIO.setup(gpio_pin, GPIO.IN, pull_up_down=GPIO.PUD_UP)

--- a/listen-for-shutdown.py
+++ b/listen-for-shutdown.py
@@ -1,12 +1,27 @@
 #!/usr/bin/env python
 
-
 import RPi.GPIO as GPIO
 import subprocess
+import time
+from time import sleep
 
+gpio_pin=3
+long_press=30
 
 GPIO.setmode(GPIO.BCM)
-GPIO.setup(3, GPIO.IN, pull_up_down=GPIO.PUD_UP)
-GPIO.wait_for_edge(3, GPIO.FALLING)
+GPIO.setup(gpio_pin, GPIO.IN, pull_up_down=GPIO.PUD_UP)
 
-subprocess.call(['shutdown', '-h', 'now'], shell=False)
+def main():
+  while True:
+    GPIO.wait_for_edge(gpio_pin, GPIO.FALLING)
+    counter = 0
+    while GPIO.input(gpio_pin) == 0 and counter < long_press:
+      time.sleep(0.1)
+      counter += 1
+      print('Shutdown button is pressed ' + str(counter))
+    if counter >= long_press:
+      print('Shutting down')
+      subprocess.call(['shutdown', '-h', 'now'], shell=False)
+
+if __name__ == '__main__':
+  main()

--- a/listen-for-shutdown.py
+++ b/listen-for-shutdown.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+
 import RPi.GPIO as GPIO
 import subprocess
 import time

--- a/listen-for-shutdown.py
+++ b/listen-for-shutdown.py
@@ -26,14 +26,11 @@ def main():
       time.sleep(0.1)
       counter = round(counter + 0.1, 1)
       print('Shutdown button is pressed ' + str(counter))
-      
-    relay_state=GPIO.input(light_gpio) or GPIO.input(fan_gpio)
-    
     if counter >= long_press:
       print('Shutting down')
       subprocess.call(['shutdown', '-h', 'now'], shell=False)
     elif counter >= short_press:
-      relay_state = not relay_state
+      relay_state = not (GPIO.input(light_gpio) or GPIO.input(fan_gpio))
       print('Changing relay state to: ' + str(relay_state))
       GPIO.output(light_gpio, relay_state)
       GPIO.output(fan_gpio, relay_state)

--- a/listen-for-shutdown.py
+++ b/listen-for-shutdown.py
@@ -25,11 +25,16 @@ def main():
     while GPIO.input(button_gpio) == 0 and counter < long_press:
       time.sleep(0.1)
       counter = round(counter + 0.1, 1)
-      print('Shutdown button is pressed ' + str(counter))
-    if counter >= long_press:
-      print('Shutting down')
-      subprocess.call(['shutdown', '-h', 'now'], shell=False)
-    elif counter >= short_press:
+      
+      if counter >= long_press:
+        print('Shutting down')
+        subprocess.call(['shutdown', '-h', 'now'], shell=False)
+        return # Exit the script as the system is shutting down
+      
+      if int(counter * 10) % 10 == 0: # Print every second to keep logs clean
+        print(f'Button held for: {counter}s')
+      
+    if counter >= short_press and counter < long_press:
       relay_state = not (GPIO.input(light_gpio) or GPIO.input(fan_gpio))
       print('Changing relay state to: ' + str(relay_state))
       GPIO.output(light_gpio, relay_state)

--- a/listen-for-shutdown.py
+++ b/listen-for-shutdown.py
@@ -8,7 +8,7 @@ from time import sleep
 
 button_gpio=3
 light_gpio=27
-fan_gpio=27
+fan_gpio=22
 
 short_press=0.1
 long_press=10

--- a/listen-for-shutdown.py
+++ b/listen-for-shutdown.py
@@ -34,7 +34,7 @@ def main():
       print('Changing relay state to: ' + str(relay_state))
       GPIO.output(light_gpio, relay_state)
       GPIO.output(fan_gpio, relay_state)
-      time.sleep(0.5)
+      time.sleep(short_press)
 
 if __name__ == '__main__':
   main()

--- a/listen-for-shutdown.py
+++ b/listen-for-shutdown.py
@@ -7,17 +7,19 @@ import time
 from time import sleep
 
 button_gpio=3
-relay_gpio=4
+light_gpio=27
+fan_gpio=27
 
 short_press=0.1
-long_press=5
+long_press=10
 
 GPIO.setmode(GPIO.BCM)
 GPIO.setup(button_gpio, GPIO.IN, pull_up_down=GPIO.PUD_UP)
-GPIO.setup(relay_gpio, GPIO.OUT)
+GPIO.setup(light_gpio, GPIO.OUT)
+GPIO.setup(fan_gpio, GPIO.OUT)
 
 def main():
-  relay_state=GPIO.input(relay_gpio)
+  relay_state=GPIO.input(light_gpio) or GPIO.input(fan_gpio)
   while True:
     GPIO.wait_for_edge(button_gpio, GPIO.FALLING)
     counter = 0
@@ -31,7 +33,8 @@ def main():
     elif counter >= short_press:
       relay_state = not relay_state
       print('Changing relay state to: ' + str(relay_state))
-      GPIO.output(relay_gpio, relay_state)
+      GPIO.output(light_gpio, relay_state)
+      GPIO.output(fan_gpio, relay_state)
       time.sleep(0.5)
 
 if __name__ == '__main__':

--- a/listen-for-shutdown.py
+++ b/listen-for-shutdown.py
@@ -19,7 +19,6 @@ GPIO.setup(light_gpio, GPIO.OUT)
 GPIO.setup(fan_gpio, GPIO.OUT)
 
 def main():
-  relay_state=GPIO.input(light_gpio) or GPIO.input(fan_gpio)
   while True:
     GPIO.wait_for_edge(button_gpio, GPIO.FALLING)
     counter = 0
@@ -27,6 +26,9 @@ def main():
       time.sleep(0.1)
       counter = round(counter + 0.1, 1)
       print('Shutdown button is pressed ' + str(counter))
+      
+    relay_state=GPIO.input(light_gpio) or GPIO.input(fan_gpio)
+    
     if counter >= long_press:
       print('Shutting down')
       subprocess.call(['shutdown', '-h', 'now'], shell=False)


### PR DESCRIPTION
The goal is to prevent inadvertent shutdowns. This can be devastating, especially when Pi is used as a 3d printing server

Variable long_press can be set to a positive integer  number of 100 ms intervals (10 for 1 s, 30 for 3s, etc.), defining for how long user needs to keep button pressed to shutdown Raspberry Pi. 

If set to 0 (default) - button press would execute shutdown command immediately