### PR TITLE
Fixes RuntimeWarning error

### DIFF
--- a/listen-for-shutdown.py
+++ b/listen-for-shutdown.py
@@ -5,6 +5,7 @@ import RPi.GPIO as GPIO
 import subprocess
 
 
+GPIO.setwarnings(False)
 GPIO.setmode(GPIO.BCM)
 GPIO.setup(3, GPIO.IN, pull_up_down=GPIO.PUD_UP)
 GPIO.wait_for_edge(3, GPIO.FALLING)


### PR DESCRIPTION
Fixes "RuntimeWarning: A physical pull up resistor is fitted on this channel! GPIO.setup(3, GPIO.IN, pull_up_down=GPIO.PUD_UP)" error

- Ref: Issue #12
- Ref: Issue #34