### PR TITLE
fix: add a custom function for polling the switch

### DIFF
--- a/listen-for-shutdown.py
+++ b/listen-for-shutdown.py
@@ -3,10 +3,16 @@
 
 import RPi.GPIO as GPIO
 import subprocess
+import time
 
+switchPin = 3
+
+def wait_for_falling_edge(gpioNumber):
+    while GPIO.input(gpioNumber):
+        time.sleep(.01)
 
 GPIO.setmode(GPIO.BCM)
-GPIO.setup(3, GPIO.IN, pull_up_down=GPIO.PUD_UP)
-GPIO.wait_for_edge(3, GPIO.FALLING)
+GPIO.setup(switchPin, GPIO.IN)
+wait_for_falling_edge(switchPin)
 
 subprocess.call(['shutdown', '-h', 'now'], shell=False)


### PR DESCRIPTION
The original script throws a RuntimeError on a RPi4: GPIO.wait_for_edge(3, GPIO.FALLING)
RuntimeError: Error waiting for edge.

This is due the wait_for_edge function that is not compatible with newer python versions.

This commit will add a function that polls the corresponding GPIO input.